### PR TITLE
fix: Fix async configuration not importing module dependencies

### DIFF
--- a/lib/bull.module.ts
+++ b/lib/bull.module.ts
@@ -17,6 +17,7 @@ export class BullModule {
   static forRootAsync(options: BullModuleAsyncOptions): DynamicModule {
     const providers: Provider[] = createAsyncQueuesProviders([].concat(options));
     return {
+      imports: options.imports,
       module: BullModule,
       components: providers,
       exports: providers,


### PR DESCRIPTION
Fixes an issue where async configuration won't import other modules. 

This wouldn't work before: 
```typescript
@Module({
  imports: [
    BullModule.forRootAsync({
      imports: [ConfigModule],
      useFactory: (configService: ConfigService) => ({
        name: 'email',
        options: {
          redis: {
            port: configService.getRedisPort(),
          },
          prefix: configService.getRedisKeyPrefix()
        }
      }),
      inject: [ConfigService],
    }),
  ],
  providers: [AppService]
})
export class AppModule { }
```